### PR TITLE
ChatSpaceメッセージ送信機能の実装

### DIFF
--- a/app/assets/stylesheets/modules/group.scss
+++ b/app/assets/stylesheets/modules/group.scss
@@ -41,14 +41,14 @@ li {
     padding-left: 20px;
     box-sizing: border-box;
   }
-  &__rightField {
-    width: 70%;
-  }
   &__label {
     display: block;
     line-height: 50px;
     font-weight: bold;
     text-align: right;
+  }
+  &__rightField {
+    width: 70%;
   }
   &__input {
     width: 100%;

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -8,7 +8,7 @@
   .SettingGroupForm__field
     .SettingGroupForm__leftField
       = f.label :name, "グループ名", class: 'SettingGroupForm__label'
-      .SettingGroupForm__rightField
+    .SettingGroupForm__rightField
       = f.text_field :name, class: 'SettingGroupForm__input', placeholder: 'グループ名を入力してください'
   .SettingGroupForm__field
     .SettingGroupForm__leftField


### PR DESCRIPTION
＃What
メッセージ送信機能、グループにメッセージを表示、サイドバーに最新のメッセージを表示、ヘッダーにグループ名とユーザー名が表示、グループ編集ページへのリンクを設置、グループ編集後のリダイレクト先を変更の実装です。

＃Why
ChatSpaceメッセージ送信の根幹機能です。